### PR TITLE
FG-2196: Change plugin minimum apple-ios version to iOS 10

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
 
 	<engines>
         <engine name="cordova-ios" version=">=4.0.0-dev" />
-        <engine name="apple-ios" version=">=9.0" />
+        <engine name="apple-ios" version=">=10.0" />
 	</engines>
 
     <!-- ios -->


### PR DESCRIPTION
@AdrianSchneider just a 1 liner because ios 9 and webkit don't behave with file uploads